### PR TITLE
Add FakeS3 location

### DIFF
--- a/share/powprox/nginx.conf.erb
+++ b/share/powprox/nginx.conf.erb
@@ -87,6 +87,12 @@ http {
 
     root "$pow_host_root/$pow_host/public";
 
+    location /fake_s3 {
+      root "$pow_host_root/$pow_host/tmp";
+      autoindex on;
+      add_header content-encoding gzip;
+    }
+
     location / {
       try_files $uri @powprox;
     }


### PR DESCRIPTION
Allows gzipped assets to be served from /fake_s3 for easier testing of
uploads