### PR TITLE
Skip self test

### DIFF
--- a/libexec/powprox-setup
+++ b/libexec/powprox-setup
@@ -145,9 +145,6 @@ generate_nginx_config
 echo "Launching Nginx"
 nginx_launchdaemon
 
-echo "Nginx self-test… "
-nginx_selftest
-
 echo "Installing ~/.pow watcher"
 install_pow_reloader
 


### PR DESCRIPTION
Skipping this since we implicitly test locally via opening up the browser, and this was executing quickly enough that nginx hadn't finished initializing sometimes, leading to early failures.

Adding a `sleep` also worked, but would slow us down! 🚀 